### PR TITLE
Fix contributors page display on mobile devices

### DIFF
--- a/css/contributors.css
+++ b/css/contributors.css
@@ -32,7 +32,7 @@ body {
   margin: 0 auto; 
   float: none; 
   margin-bottom: 10px; 
-  width: 400px;
+  max-width: 400px;
   text-align: center;
 }
 .jumbotron {


### PR DESCRIPTION
Changed "card" img width from static 400px to maximum 400px so that it looks the same on wider screens but shrinks on mobile devices.

closes #113 