### PR TITLE
Add: Hover States & Social Icon CSS changes

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -3,8 +3,13 @@
     left: 0;
     bottom: 0;
     width: 100%;
-    background-color: rgba(0, 0, 0, 0.7);
+    background-color: rgba(204, 6, 54, 0.5);
     color: white;
+    text-shadow:
+    -.3px -.3px 0 #000,  
+     .3px -.3px 0 #000,
+     -.3px .3px 0 #000,
+      .3px .3px 0 #000;
     text-align: center;
 }
 
@@ -14,7 +19,17 @@
 
 .social-icons {
     padding: 5px;
+    margin-bottom: 10px;
     display: none;
+}
+
+
+.social-icons > a img {
+   transition: all .2s ease-in-out; 
+  }
+
+  .social-icons > a img:hover {
+    transform: scale(1.1); 
 }
 
 #footer h3 span:hover {


### PR DESCRIPTION
-Added hover state to social icons
-Changed footer color to light-opacity pink so GitHub icon could be seen when scrolled up to the darker background videos at the top of the page.
-Gave `.social-icons` bottom margin to give icons more breathing room when drawer is open. 
-Added text stroke for read-ability. 