### PR TITLE
Fixed path links

### DIFF
--- a/cheese.html
+++ b/cheese.html
@@ -21,7 +21,7 @@
 
     <img id="sublogo" src="./images/lingon-saft.png" />
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <a class="navbar-brand" href="./index.html">Hacktoberfest  - by Lingonsaft</a>
+    <a class="navbar-brand" href="/">Hacktoberfest  - by Lingonsaft</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -29,16 +29,16 @@
     <div class="collapse navbar-collapse" id="navbarColor01">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item">
-          <a class="nav-link" href="./index.html">Home</a>
+          <a class="nav-link" href="/">Home</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="./helpful-material.html">Helpful Material</a>
+          <a class="nav-link" href="/helpful-material">Helpful Material</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="./contributors.html">Contributors</a>
+          <a class="nav-link" href="/contributors">Contributors</a>
         </li>
         <li class="nav-item active">
-          <a class="nav-link" href="./cheese.html">Cheese!</a>
+          <a class="nav-link" href="/cheese">Cheese!</a>
         </li>
       </ul>
 

--- a/contributors.html
+++ b/contributors.html
@@ -62,6 +62,7 @@
           <div class="card mb-4 shadow-sm">
             <img class="card">
             <div class="card-body">
+              <p class="card-text"><a href="https://github.com/araanbranco">Araan branco</a></p>
               <p class="card-text"><a href="https://github.com/richie-south">richie-south</a></p>
               <p class="card-text"><a href="https://github.com/BennyCarlsson">BennyCarlsson</a></p>
               <p class="card-text"><a href="https://github.com/pvn6396/">Pavan Choudhary</a></p>

--- a/contributors.html
+++ b/contributors.html
@@ -20,7 +20,7 @@
 
   <img id="sublogo" src="./images/lingon-saft.png" />
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <a class="navbar-brand" href="./index.html">Hacktoberfest - by Lingonsaft</a>
+    <a class="navbar-brand" href="/">Hacktoberfest - by Lingonsaft</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01"
       aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
@@ -29,16 +29,16 @@
     <div class="collapse navbar-collapse" id="navbarColor01">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item">
-          <a class="nav-link" href="./index.html">Home</a>
+          <a class="nav-link" href="/">Home</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="./helpful-material.html">Helpful Material</a>
+          <a class="nav-link" href="/helpful-material">Helpful Material</a>
         </li>
         <li class="nav-item active">
-          <a class="nav-link" href="./contributors.html">Contributors</a>
+          <a class="nav-link" href="/contributors">Contributors</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="./cheese.html">Cheese!</a>
+          <a class="nav-link" href="/cheese">Cheese!</a>
         </li>
       </ul>
 

--- a/helpful-material.html
+++ b/helpful-material.html
@@ -16,7 +16,7 @@
 <body>
     <button onclick="topFunction()" class="btn btn-danger" id="myBtn" title="Go to top"><img src="https://png.icons8.com/ios/50/000000/circled-chevron-up.png"></button>
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <a class="navbar-brand" href="./index.html">Hacktoberfest</a>
+    <a class="navbar-brand" href="/">Hacktoberfest</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -24,16 +24,16 @@
     <div class="collapse navbar-collapse" id="navbarColor01">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item">
-          <a class="nav-link" href="./index.html">Home</a>
+          <a class="nav-link" href="/">Home</a>
         </li>
         <li class="nav-item active">
-          <a class="nav-link" href="./helpful-material.html">Helpful Material</a>
+          <a class="nav-link" href="/helpful-material">Helpful Material</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="./contributors.html">Contributors</a>
+          <a class="nav-link" href="/contributors">Contributors</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="./cheese.html">Cheese!</a>
+          <a class="nav-link" href="/cheese">Cheese!</a>
         </li>
       </ul>
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   <!--Navbar-->
   <button onclick="topFunction()" class="btn btn-danger" id="myBtn" title="Go to top"><img src="https://png.icons8.com/ios/50/000000/circled-chevron-up.png"></button>
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <a class="navbar-brand" href="./index.html">Hacktoberfest</a>
+    <a class="navbar-brand" href="/">Hacktoberfest</a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
@@ -34,19 +34,19 @@
     <div class="collapse navbar-collapse" id="navbarColor01">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item active">
-          <a class="nav-link" href="./index.html">Home</a>
+          <a class="nav-link" href="/">Home</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="./helpful-material.html">Helpful Material</a>
+          <a class="nav-link" href="/helpful-material">Helpful Material</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="./contributors.html">Contributors</a>
+          <a class="nav-link" href="/contributors">Contributors</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" id="twist" href="#">The twist</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="./cheese.html">Cheese!</a>
+          <a class="nav-link" href="/cheese">Cheese!</a>
         </li>
       </ul>
 


### PR DESCRIPTION
By solving path problems, there is probably some configuration on the server that hosts the site and removes the .html from the link, for example: https://hacktoberfest.lingonsaft.com/contributors or https://hacktoberfest.lingonsaft.com/helpful-material

issue #252