### PR TITLE
fix navbar link to helpful material (#322)

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
           <a class="nav-link" href="/">Home</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/helpful-material">Helpful Material</a>
+          <a class="nav-link" href="./helpful-material">Helpful Material</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="/contributors">Contributors</a>


### PR DESCRIPTION
The link was broken locally because it wasn't using relative path.
Any suggestion to test if that would work on production environment?