### PR TITLE
Twist menu

### DIFF
--- a/cheese.html
+++ b/cheese.html
@@ -45,9 +45,6 @@
         <li class="nav-item">
           <a class="nav-link" href="/contributors">Contributors</a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link" id="twist" href="#">The twist</a>
-        </li>
         <li class="nav-item active">
           <a class="nav-link" href="/cheese">Cheese!</a>
         </li>

--- a/index.html
+++ b/index.html
@@ -68,9 +68,6 @@
           <a class="nav-link" href="/contributors">Contributors</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" id="twist" href="#">The twist</a>
-        </li>
-        <li class="nav-item">
           <a class="nav-link" href="./potato.html">Potato</a>
         </li>
         <li class="nav-item">
@@ -81,6 +78,9 @@
         </li>
         <li class="nav-item ml-lg-auto">
           <a class="nav-link" id="invert-btn" href="#">Invert</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" id="twist" href="#">The twist</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="/tools">Tools</a>

--- a/tools.html
+++ b/tools.html
@@ -42,10 +42,6 @@
             <li class="nav-item">
                 <a class="nav-link" href="/contributors">Contributors</a>
             </li>
-            <li class="nav-item">
-                <a class="nav-link" id="twist" href="#">The twist</a>
-            </li>
-            <li class="nav-item">
                 <a class="nav-link" href="/cheese">Cheese!</a>
             </li>
             <li class="nav-item active">


### PR DESCRIPTION
Twist menu moved next to Invert and removed from all pages but homepage
Fix for [#460](https://github.com/lingonsaft/hacktoberfest/issues/460)