### PR TITLE
Fix page links for local

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -94,6 +94,7 @@
         <p class="card-item"><a href="https://github.com/Cyclia">Cyclia</a></p>
         <p class="card-item"><a href="https://github.com/vs4vijay">vs4vijay</a></p>
         <p class="card-item"><a href="https://github.com/KSSBro">KSSBro</a></p>
+        <p class="card-item"><a href="https://github.com/christophwong">Christoph Wong</a></p>
         <p class="card-item"><a href="https://github.com/haych8">Haych8</a></p>
         <p class="card-item"><a href="https://github.com/webhead3">NotArland</a></p>
         <p class="card-item"><a href="https://github.com/HarveyD">Harvey</a></p>

--- a/helpful-material.html
+++ b/helpful-material.html
@@ -35,10 +35,10 @@
       <div class="collapse navbar-collapse" id="navbarColor01">
           <ul class="navbar-nav mr-auto">
               <li class="nav-item">
-                  <a class="nav-link" href="/">Home</a>
+                  <a class="nav-link" href="./index.html">Home</a>
               </li>
               <li class="nav-item active">
-                  <a class="nav-link" href="/helpful-material">Helpful Material</a>
+                  <a class="nav-link" href="./helpful-material.html">Helpful Material</a>
               </li>
               <li class="nav-item">
                   <a class="nav-link" href="/contributors">Contributors</a>

--- a/helpful-material.html
+++ b/helpful-material.html
@@ -26,7 +26,7 @@
 
 <body>
       <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-        <a class="navbar-brand" href="/">Hacktoberfest</a>
+        <a class="navbar-brand" href="./index.html">Hacktoberfest</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01"
         aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
   <button onclick="topFunction()" class="btn btn-danger" id="myBtn" title="Go to top"><img src="https://png.icons8.com/ios/50/000000/circled-chevron-up.png"
       alt="circled-chevron-up icon" /></button>
   <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-    <a class="navbar-brand" href="/">Hacktoberfest</a>
+    <a class="navbar-brand" href="./index.html">Hacktoberfest</a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01"
       aria-expanded="false" aria-label="Toggle navigation">

--- a/index.html
+++ b/index.html
@@ -59,10 +59,10 @@
     <div class="collapse navbar-collapse" id="navbarColor01">
       <ul class="navbar-nav mr-auto">
         <li class="nav-item active">
-          <a class="nav-link" href="/">Home</a>
+          <a class="nav-link" href="./index.html">Home</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/helpful-material">Helpful Material</a>
+          <a class="nav-link" href="./helpful-material.html">Helpful Material</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="/contributors">Contributors</a>


### PR DESCRIPTION
The navbar does not work locally and makes testing harder.
Now the links "home" and "helpful-material" and the brand logo link to their respective html pages, so even when running the page locally, we can navigate via the links.