### PR TITLE
Contributors page home link fixed.

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -29,7 +29,7 @@
         </svg>
       </a>
       <ul class="top-nav--secondary">
-        <li><a href="./idex.html">Hacktoberfest</a></li>
+        <li><a href="./index.html">Hacktoberfest</a></li>
         <li><a href="./helpful-material.html">Helpful Material</a></li>
         <li><a class="active" href="./contributors.html">Contributors</a></li>
         <li class="dropdown drop">

--- a/contributors.html
+++ b/contributors.html
@@ -69,6 +69,7 @@
 		<p class="card-item"><a href="https://github.com/dwikychandra21">Dwiky Chandra</a></p>
         <p class="card-item"><a href="https://github.com/n00d13">n00d13</a></p>
         <p class="card-item"><a href="https://github.com/sn149">sn149</a></p>
+        <p class="card-item"><a href="https://github.com/ViniciusALS">ViniciusALS</a></p>
         <p class="card-item"><a href="https://github.com/CodinMaster">Apoorv Lathey</a></p>
         <p class="card-item"><a href="https://github.com/araanbranco">Araan branco</a></p>
         <p class="card-item"><a href="https://github.com/richie-south">richie-south</a></p>


### PR DESCRIPTION
The link to the home page on the contributors page was leading to a 404 page. This bug was fixed on this PR.

My name and github profile were added to the contributors list as well.