### PR TITLE
Fix "ReferenceError: fetchRequest is not defined"

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -46,7 +46,7 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
 	let request = event.request;
 	event.respondWith (
-			fetch(fetchRequest).then(
+			fetch(request).then(
 				(response) => {
 					//check valid response basic means we do NOT cache 3rd party responses
 					if(!response || response.status !== 200 || response.type !== 'basic') {


### PR DESCRIPTION
Fixed "ReferenceError: fetchRequest is not defined" which occur when something is fetched.