### PR TITLE
 Use UMD popper's version and stop using ESM popper's version to prevent module exportation error

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
   <!-- Latest compiled JavaScript -->
 
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.4/esm/popper.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.4/umd/popper.min.js"></script>
   <script type="text/javascript" src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
   <script type="application/javascript" charset="utf-8" src="register.js"></script>
   <script type="application/javascript" charset="utf-8" src="sw.js"></script>


### PR DESCRIPTION
Fix "SyntaxError: export declarations may only appear at top level of a module" from popper ESM version.