### PR TITLE
Change classic function into arrow function in sw.js

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -60,7 +60,7 @@ self.addEventListener('fetch', (event) => {
 						});
 					return response;
 				}
-			).catch(function (err){
+			).catch((err) => {
 				caches.match(request).then((response) => {
 					if (response) {
 						return response;


### PR DESCRIPTION
Use arrow function instead of classic function to use the same standard everywhere in the code.