### PR TITLE
update href property to use caps as html file is capitalized

### DIFF
--- a/menu.json
+++ b/menu.json
@@ -32,7 +32,7 @@
     },
     "Fireworks": {
       "text": "Fireworks",
-      "href": "/fireworks",
+      "href": "/Fireworks",
       "id": "fireworks"
     },
     "Learn": {


### PR DESCRIPTION
This should fix it, but I was having a hard time testing the site locally. I tested the fix by editing the href through debug tools, so I think this should do it.