### PR TITLE
Fix .footer-icon color syntax problem. Who did that?

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -17,8 +17,8 @@
 }
 
 .footer-icon {
-    color: ##e6e6fa;
-  }
+    color: #e6e6fa;
+}
 
 .social-icons {
     padding: 5px;


### PR DESCRIPTION
Fix double `#` characters at the color's declaration