### PR TITLE
Do not delay initial countdown

### DIFF
--- a/scripts/countdown.js
+++ b/scripts/countdown.js
@@ -4,7 +4,7 @@ const minute = second * 60
 const hour = minute * 60
 const day = hour * 24
 
-setInterval(() => {
+function updateTime() {
   let dateNow = new Date().getTime()
   let timeLeft = endOfHackathon - dateNow
 
@@ -12,4 +12,6 @@ setInterval(() => {
   document.getElementById('hours').innerText = Math.floor((timeLeft % (day)) / (hour))
   document.getElementById('minutes').innerText = Math.floor((timeLeft % (hour)) / (minute))
   document.getElementById('seconds').innerText = Math.floor((timeLeft % (minute)) / second)
-}, second)
+}
+updateTime();
+setInterval(updateTime, second)


### PR DESCRIPTION
The countdown was waiting a second before setting the initial countdown value which added an unnecessary jump for the text.