### PR TITLE
Add OpenBS Hacktoberfest under helpful links

### DIFF
--- a/helpful-material.html
+++ b/helpful-material.html
@@ -241,6 +241,7 @@
           <li><a class="list-item" href="https://rooksguide.files.wordpress.com/2013/12/rooks-guide-isbn-version.pdf">Rooks Guide to C++</a></li>
           <li><a href="https://www.youtube.com/watch?v=3RjQznt-8kE&list=PL4cUxeGkcC9goXbgTDQ0n_4TBzOO0ocPR" target="_blank" class="list-item">Net Ninja: Git and GitHub Tutorials on YouTube</a></li>
           <li><a class="list-item" href="https://robots.thoughtbot.com/keeping-a-github-fork-updated">Keeping a Github Fork Updated</a></li>
+          <li><a class="list-item" href="https://blog.openebs.io/celebrate-hacktoberfest-2018-with-openebs-206daa1d653c">Celebrate Hacktoberfest 2018 with OpenEBS! (And win a T Shirt!)</a></li>
         </div>
       </div>
       <div class="section">


### PR DESCRIPTION
Added  [Celebrate Hacktoberfest 2018 with OpenEBS! (And win a T Shirt!)](https://blog.openebs.io/celebrate-hacktoberfest-2018-with-openebs-206daa1d653c) under Helpful links