### PR TITLE
fixing example on contributors page and adding me to contributors page.

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -303,9 +303,10 @@
         <a class="box-item" href="https://github.com/samholst">Sam Holst</a>
         <a class="box-item different-color" href="https://github.com/adityaas26">Aditya Sharma</a>
         <a class="box-item" href="https://github.com/blackburn3333">Jayendra Matarage</a>
+        <a class="box-item" href="https://github.com/harnerdesigns">Jack Harner</a>
         <!--
         Add here
-        format : <a class="box-item"> href="https://github.com/<your-username>">Your Name</a>
+        format : <a class="box-item" href="https://github.com/<your-username>">Your Name</a>
         -->
       </div>
     </div>


### PR DESCRIPTION
the format on the contributors page had an extra closing bracket on the link. I fixed it. 