### PR TITLE
Disable scroll for snek fun

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -316,6 +316,7 @@
         <a class="box-item" href="https://github.com/denisepen">Denise Pendleton-Lipinski</a>
         <a class="box-item" href="https://github.com/Axieum">Axieum</a>4
         <a class="box-item" href="https://github.com/TheVzard">Vivek Gover</a>
+        <a class="box-item" href="https://github.com/christophwong">Christoph Wong</a>
 
         <!--
         Add here

--- a/scripts/snek.js
+++ b/scripts/snek.js
@@ -193,6 +193,7 @@ function drawSnake() {
  * @param {KeyboardEvent} e
  */
 function changeDirection(e) {
+  e.preventDefault();
   if (DirectionKeys[e.keyCode]) {
     const currentDirection = state.direction
     const nextDirection = DirectionKeys[e.keyCode]


### PR DESCRIPTION
Prevent DOM from scrolling around when playing snek with arrow keys

Add preventDefault() to the key-down event in snek.js.
This stops the default action of key-down which for up / down arrow keys
will be scrolling in some browsers. By stopping that action, we can snek
on stable ground.