### PR TITLE
refactor(styles): break out index styles

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1,110 +1,6 @@
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800&subset=latin-ext');
 @import url('https://fonts.googleapis.com/css?family=Montserrat:400,500,600,700,800,900&subset=latin-ext');
 
-.spinCard{
-  -webkit-animation:spin 4s linear infinite;
-  -o-animation:spin 4s linear infinite;
-  -moz-animation:spin 4s linear infinite;
-  animation:spin 4s linear infinite;
-}
-
-@-webkit-keyframes spin {
-  100% {
-    -webkit-transform: rotate3d(1, 1, 1, 360deg);
-  }
-}
-
-@keyframes spin {
-  100% {
-    -webkit-transform: rotate3d(1, 1, 1, 360deg);
-    -o-transform: rotate3d(1, 1, 1, 360deg);
-    -moz-transform: rotate3d(1, 1, 1, 360deg);
-    transform: rotate3d(1, 1, 1, 360deg);
-  }
-}
-
-@keyframes twist {
-  from {
-      transform: rotateY(0deg);
-  }
-  to {
-      transform: rotateY(360deg);
-  }
-}
-
-@keyframes animate {
-  0% {
-    background-position: 0%;
-  }
-  100% {
-    background-position: 400%;
-  }
-}
-
-@keyframes jump {
-  0% {
-    transform: translateY(0px);
-  }
-  50% {
-    transform: translateY(-20px);
-  }
-  70% {
-    transform: translateY(10px);
-  }
-  100% {
-    transform: translateY(0px);
-  }
-}
-
-
-* {
-  outline: none!important;
-}
-
-.icon-bar a {
-  display: block;
-  text-align: center;
-  padding: 16px;
-  transition: all 0.3s ease;
-  color: white;
-  font-size: 20px;
-}
-
-.icon-bar a:hover {
-  /* width: 7rem; */
-  background: #000;
-}
-
-.icon-bar a:hover i {
-  animation-name: twist;
-  animation-duration: 1s;
-}
-
-.facebook {
-  background: #3B5998;
-  color: white;
-}
-
-.twitter {
-  background: #55ACEE;
-  color: white;
-}
-
-.insta {
-  background: #dd4b39;
-  color: white;
-}
-
-.linkedin {
-  background: #007bb5;
-  color: white;
-}
-
-.youtube {
-  background: #bb0000;
-  color: white;
-}
-
 html {
   overflow-x: hidden;
 }
@@ -114,21 +10,23 @@ body {
   color: #000;
   line-height: 1.9;
   margin: 0;
-  background:linear-gradient(to right,#25CCF7,#487EB0);
-  font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  letter-spacing: .75px;
+  background: linear-gradient(to right, #25ccf7, #487eb0);
+  font-family: 'Open Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol';
+  letter-spacing: 0.75px;
   margin: 0;
   overflow-x: hidden;
   transition: 1s ease-in-out;
 }
 
-.hack-title{
+.hack-title {
   font-family: 'Pacifico', cursive;
   font-size: 70px !important;
 }
 
 .h1-hover:hover {
-  cursor: url("../images/NinjaDuck_min.jpg"), pointer;
+  cursor: url('../images/NinjaDuck_min.jpg'), pointer;
 }
 
 h1,
@@ -143,7 +41,7 @@ h6 {
 
 a,
 a:hover {
-  color: #FF0844;
+  color: #ff0844;
   transition: all 500ms ease-in-out;
 }
 
@@ -154,11 +52,11 @@ a:hover {
 .index .jumbotron {
   padding: 4rem 0;
   background-color: #ffeff3;
-
 }
+
 .jumbotron:first-child {
   margin-bottom: 0;
-  background: linear-gradient(to bottom, #fff 0%,#ffeff3 100%);
+  background: linear-gradient(to bottom, #fff 0%, #ffeff3 100%);
 }
 
 .index .jumbotron:first-child {
@@ -200,22 +98,22 @@ a:hover {
   letter-spacing: 1px;
   font-size: 14px;
   font-weight: 600;
-  padding: .5rem .75rem .5rem 2.5rem;
+  padding: 0.5rem 0.75rem 0.5rem 2.5rem;
   border-radius: 2rem;
-  margin: 0 .3rem;
+  margin: 0 0.3rem;
 }
 
 .index .btn svg {
   position: absolute;
-  left: .4em;
-  top: .2em;
+  left: 0.4em;
+  top: 0.2em;
   width: auto;
   height: 30px;
 }
 
 .index .btn-danger {
   color: #fff;
-  background-color: #FF0844;
+  background-color: #ff0844;
 }
 
 .btn-subscribe > svg {
@@ -239,17 +137,175 @@ a:hover {
 }
 
 .no:hover {
-    transform: scale(1.25);
+  transform: scale(1.25);
 }
 
 .video .card:hover {
-  color: #FF0844;
-  box-shadow: 0 .125rem .25rem rgba(0, 0, 0, .075)!important;
-  animation : jump 0.5s ease forwards;
+  color: #ff0844;
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important;
+  animation: jump 0.5s ease forwards;
 }
 #intro_video {
-    display: block
+  display: block;
 }
+
+.github-corner:hover .octo-arm {
+  animation: octocat-wave 560ms ease-in-out;
+}
+
+@keyframes octocat-wave {
+  0%,
+  100% {
+    transform: rotate(0);
+  }
+  20%,
+  60% {
+    transform: rotate(-25deg);
+  }
+  40%,
+  80% {
+    transform: rotate(10deg);
+  }
+}
+
+@media (max-width: 992px) {
+  .github-corner > svg {
+    z-index: -1;
+    width: 40px;
+    height: 40px;
+  }
+}
+
+@media (max-width: 500px) {
+  .github-corner:hover .octo-arm {
+    animation: none;
+  }
+
+  .github-corner .octo-arm {
+    animation: octocat-wave 560ms ease-in-out;
+  }
+}
+.btn {
+  margin: 15px !important;
+  position: relative;
+  z-index: 1;
+  transition: box-shadow 400ms cubic-bezier(0.2, 0, 0.7, 1),
+    -webkit-transform 200ms cubic-bezier(0.2, 0, 0.7, 1);
+  transition: box-shadow 400ms cubic-bezier(0.2, 0, 0.7, 1),
+    transform 200ms cubic-bezier(0.2, 0, 0.7, 1);
+  transition: box-shadow 400ms cubic-bezier(0.2, 0, 0.7, 1),
+    transform 200ms cubic-bezier(0.2, 0, 0.7, 1),
+    -webkit-transform 200ms cubic-bezier(0.2, 0, 0.7, 1);
+}
+
+.btn:hover {
+  box-shadow: 0 0 1px 15px rgba(112, 143, 2, 0.4),
+    0 0 1px 30px rgba(183, 185, 18, 0.1), 0 0 1px 45px rgba(138, 59, 88, 0.1);
+}
+
+.spinCard {
+  -webkit-animation: spin 4s linear infinite;
+  -o-animation: spin 4s linear infinite;
+  -moz-animation: spin 4s linear infinite;
+  animation: spin 4s linear infinite;
+}
+
+@-webkit-keyframes spin {
+  100% {
+    -webkit-transform: rotate3d(1, 1, 1, 360deg);
+  }
+}
+
+@keyframes spin {
+  100% {
+    -webkit-transform: rotate3d(1, 1, 1, 360deg);
+    -o-transform: rotate3d(1, 1, 1, 360deg);
+    -moz-transform: rotate3d(1, 1, 1, 360deg);
+    transform: rotate3d(1, 1, 1, 360deg);
+  }
+}
+
+@keyframes twist {
+  from {
+    transform: rotateY(0deg);
+  }
+  to {
+    transform: rotateY(360deg);
+  }
+}
+
+@keyframes animate {
+  0% {
+    background-position: 0%;
+  }
+  100% {
+    background-position: 400%;
+  }
+}
+
+@keyframes jump {
+  0% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-20px);
+  }
+  70% {
+    transform: translateY(10px);
+  }
+  100% {
+    transform: translateY(0px);
+  }
+}
+
+* {
+  outline: none !important;
+}
+
+.icon-bar a {
+  display: block;
+  text-align: center;
+  padding: 16px;
+  transition: all 0.3s ease;
+  color: white;
+  font-size: 20px;
+}
+
+.icon-bar a:hover {
+  /* width: 7rem; */
+  background: #000;
+}
+
+.icon-bar a:hover i {
+  animation-name: twist;
+  animation-duration: 1s;
+}
+
+.facebook {
+  background: #3b5998;
+  color: white;
+}
+
+.twitter {
+  background: #55acee;
+  color: white;
+}
+
+.insta {
+  background: #dd4b39;
+  color: white;
+}
+
+.linkedin {
+  background: #007bb5;
+  color: white;
+}
+
+.youtube {
+  background: #bb0000;
+  color: white;
+}
+
 .single-faq {
   border: 1px solid rgb(247, 36, 133);
   padding: 1rem;
@@ -258,7 +314,7 @@ a:hover {
 }
 
 .single-faq:hover {
-    transform: scale(1.02);
+  transform: scale(1.02);
 }
 
 .single-faq h5 {
@@ -312,7 +368,7 @@ a:hover {
   vertical-align: middle;
   text-align: center;
   margin: 10px 0;
-  border-left: 1px solid rgba(0, 0, 0, .125);
+  border-left: 1px solid rgba(0, 0, 0, 0.125);
 }
 
 .single-tips span {
@@ -322,8 +378,8 @@ a:hover {
 .single-tips .no {
   font-size: 35px;
   font-weight: 600;
-  line-height: .6;
-  color: #FF0844;
+  line-height: 0.6;
+  color: #ff0844;
   margin-bottom: 15px;
 }
 
@@ -340,10 +396,10 @@ a:hover {
 }
 
 .broccoli-green {
-  background-color: #A5D6A7;
+  background-color: #a5d6a7;
 }
 
-html [type=button] {
+html [type='button'] {
   -webkit-appearance: none !important;
   -moz-appearance: none !important;
   -o-appearance: none !important;
@@ -367,38 +423,34 @@ html [type=button] {
   font-size: 20px;
 }
 
-#tips{
+#tips {
   border-radius: 5px;
 }
 
-#btnsh:hover{
-
-color: white;
-
-
+#btnsh:hover {
+  color: white;
 }
-#btnsh{
-
-color: black;
-
-
+#btnsh {
+  color: black;
 }
-div#content div#contribution-rules ul, div#content div#contribution-rules ul li{
+
+div#content div#contribution-rules ul,
+div#content div#contribution-rules ul li {
   list-style-type: none;
 }
 
-#contribution-rules{
+#contribution-rules {
   background-color: #fff;
-  padding:30px;
+  padding: 30px;
   border-radius: 5px;
 }
 
-.do{
-  color:green;
+.do {
+  color: green;
 }
 
-.dont{
-  color:red;
+.dont {
+  color: red;
 }
 
 .fork_image {
@@ -409,11 +461,12 @@ div#content div#contribution-rules ul, div#content div#contribution-rules ul li{
   margin-top: 61px;
 }
 
-.card-header{
-  padding:3px;
-  padding-left:20px;
-  font-weight:bold;
+.card-header {
+  padding: 3px;
+  padding-left: 20px;
+  font-weight: bold;
 }
+
 .card {
   margin: 1%;
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
@@ -423,7 +476,7 @@ div#content div#contribution-rules ul, div#content div#contribution-rules ul li{
 
 .container-fluid a {
   text-decoration: none;
-  color: #FF0844;
+  color: #ff0844;
 }
 
 .container-fluid a:hover {
@@ -501,7 +554,7 @@ div#content div#contribution-rules ul, div#content div#contribution-rules ul li{
 }
 
 .logo-image:hover {
-  cursor: url("../images/NinjaDuck_min.jpg"), not-allowed;
+  cursor: url('../images/NinjaDuck_min.jpg'), not-allowed;
 }
 
 /* Youtube Subscribe Styling */
@@ -524,7 +577,7 @@ div#content div#contribution-rules ul, div#content div#contribution-rules ul li{
 }
 
 .btn-youtube:before {
-  content: "";
+  content: '';
   z-index: -1;
   background: linear-gradient(90deg, red, orange, yellow, red);
   background-size: 400%;
@@ -539,7 +592,6 @@ div#content div#contribution-rules ul, div#content div#contribution-rules ul li{
   animation: animate 8s linear infinite;
 }
 
-
 .ytSubscribeContainer {
   margin-top: 25px;
 }
@@ -553,7 +605,7 @@ div#content div#contribution-rules ul, div#content div#contribution-rules ul li{
 }
 
 .yt-logo {
-  background: url("../images/you_logo.png");
+  background: url('../images/you_logo.png');
 }
 
 /* Start Hacking Button Animation  */
@@ -580,7 +632,7 @@ div#content div#contribution-rules ul, div#content div#contribution-rules ul li{
 }
 
 .btn-primary:before {
-  content: "";
+  content: '';
   z-index: -1;
   background: linear-gradient(90deg, red, orange, yellow, red);
   background-size: 400%;
@@ -594,7 +646,6 @@ div#content div#contribution-rules ul, div#content div#contribution-rules ul li{
   opacity: 1;
   animation: animate 8s linear infinite;
 }
-
 
 #love {
   animation-duration: 1s;
@@ -617,27 +668,27 @@ div#content div#contribution-rules ul, div#content div#contribution-rules ul li{
 #twist {
   margin-top: 50px;
   margin-bottom: 50px;
-  background-color: #FF0844;
+  background-color: #ff0844;
   color: white;
   border-radius: 2rem;
   font-weight: 600;
-  padding: .75rem 4rem .75rem 4rem;
+  padding: 0.75rem 4rem 0.75rem 4rem;
   border-radius: 2rem;
-  outline : none;
-  border : none;
+  outline: none;
+  border: none;
   box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.3);
   cursor: pointer;
 }
 
-.video-border{
-  border: solid #FF0844 1px;
+.video-border {
+  border: solid #ff0844 1px;
   border-bottom-left-radius: 25px;
-  border-bottom-right-radius:  25px;
+  border-bottom-right-radius: 25px;
 }
 
 @media (min-width: 992px) {
   .single-tips .tip {
-    border-left: 1px solid rgba(0,0,0,.125);
+    border-left: 1px solid rgba(0, 0, 0, 0.125);
     margin: 0;
   }
 

--- a/index.html
+++ b/index.html
@@ -95,52 +95,6 @@
                   fill="currentColor" class="octo-body"></path>
         </svg>
     </a>
-    <style>.github-corner:hover .octo-arm {
-        animation: octocat-wave 560ms ease-in-out
-    }
-
-    @keyframes octocat-wave {
-        0%, 100% {
-            transform: rotate(0)
-        }
-        20%, 60% {
-            transform: rotate(-25deg)
-        }
-        40%, 80% {
-            transform: rotate(10deg)
-        }
-    }
-
-    @media (max-width: 992px) {
-        .github-corner > svg {
-            z-index: -1;
-            width: 40px;
-            height: 40px;
-        }
-    }
-
-    @media (max-width: 500px) {
-        .github-corner:hover .octo-arm {
-            animation: none
-        }
-
-        .github-corner .octo-arm {
-            animation: octocat-wave 560ms ease-in-out
-        }
-    }
-	.btn {
-                margin: 15px !important;
-                position: relative;
-                z-index: 1;
-                transition: box-shadow 400ms cubic-bezier(0.2, 0, 0.7, 1), -webkit-transform 200ms cubic-bezier(0.2, 0, 0.7, 1);
-                transition: box-shadow 400ms cubic-bezier(0.2, 0, 0.7, 1), transform 200ms cubic-bezier(0.2, 0, 0.7, 1);
-                transition: box-shadow 400ms cubic-bezier(0.2, 0, 0.7, 1), transform 200ms cubic-bezier(0.2, 0, 0.7, 1), -webkit-transform 200ms cubic-bezier(0.2, 0, 0.7, 1);
-            }
-
-            .btn:hover {
-                box-shadow: 0 0 1px 15px rgba(112, 143, 2, 0.4), 0 0 1px 30px rgba(183, 185, 18, 0.1), 0 0 1px 45px rgba(138, 59, 88, 0.1);
-            }
-</style>
     <a class="navbar-brand" href="/">
         <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve" role="img" aria-labelledby="dyn2wm4vin1xgraye3ggy9kf12oaz8a" class="header__logo" width="50px" height="50px"><title id="dyn2wm4vin1xgraye3ggy9kf12oaz8a">Hacktoberfest</title>
 		  <style type="text/css">


### PR DESCRIPTION
* Removes all styles that are within `<style>` tags into the index.css
file. 
* Rearranges index.css to have a bit more sanity in the structure. There should probably be a separate issue for giving the .css files some love.

This issue addresses #1831 