### PR TITLE
Improve the creations list page

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -431,6 +431,7 @@
       	<a class="box-item different-color" href="https://github.com/srajan96">Srajan Soni</a>
         <a class="box-item" href="https://github.com/allenshaji">Allen Shaji</a>
         <a class="box-item" href="https://github.com/rbrandonwest">Ray West</a>
+        <a class="box-item" href="https://github.com/kylejlin">Kyle Lin</a>
         <!--
         Add here
         format : <a class="box-item" href="https://github.com/<your-username>">Your Name</a>
@@ -482,6 +483,7 @@
               <li><a href="cmatrix.html">C Matrix</a></li>
               <li><a href="hello.html">Hello</a></li>
               <li><a href="goforhack.html">Go Hacking</a></li>
+              <li><a href="creations.html">List of all creations</a></li>
           </ul>
       </div>
   </div>
@@ -506,7 +508,7 @@
                 </div>
             </div>
     </div>
-	
+
 <button id="backToTop" type="button" title="Back to Top">
     <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Capa_1" x="0px"
       y="0px" width="512px" height="512px" viewBox="0 0 284.929 284.929" style="enable-background:new 0 0 284.929 284.929;"

--- a/creations.html
+++ b/creations.html
@@ -75,9 +75,17 @@
         var nonIndexHtmlFiles = files.filter(
           f => /\.html$/.test(f.name) && f.name !== 'index.html'
         );
-        nonIndexHtmlFiles.forEach(file => {
+        shuffle(nonIndexHtmlFiles).forEach(file => {
           createLink(file.path);
         });
+      }
+
+      function shuffle(array) {
+        var i = 2048;
+        while (i--) {
+          array.sort(() => Math.random() - 0.5);
+        }
+        return array;
       }
 
       function createLink(path) {

--- a/creations.html
+++ b/creations.html
@@ -44,9 +44,11 @@
         background-color: #444;
       }
 
-      iframe {
+      iframe, .placeholder {
         width: 40vw;
         height: 40vh;
+        display: inline-block;
+        border: 1px solid white;
       }
 
       .overlay {
@@ -81,17 +83,24 @@
       function createLink(path) {
         var li = document.createElement('li');
         var header = document.createElement('h3');
-        var iframe = document.createElement('iframe');
+        var placeholder = document.createElement('div');
         var overlay = document.createElement('div');
         var url = 'https://hacktoberfest.lingonsaft.com/' + path;
         header.innerHTML = path.split('.html')[0];
-        iframe.src = url;
+        placeholder.classList.add('placeholder');
         overlay.addEventListener('click', () => {
           window.open(url);
         });
+        function onMouseOver() {
+          var iframe = document.createElement('iframe');
+          iframe.src = url;
+          li.replaceChild(iframe, placeholder);
+          overlay.removeEventListener('mouseover', onMouseOver);
+        }
+        overlay.addEventListener('mouseover', onMouseOver);
         overlay.classList.add('overlay');
         li.appendChild(header);
-        li.appendChild(iframe);
+        li.appendChild(placeholder);
         li.appendChild(overlay);
         ul.appendChild(li);
       }


### PR DESCRIPTION
I discovered that trying to load ~90 iframes at once was terrible for performance, especially on mobile. Hence, I modified my creation list page to only load the creation's iframe if the user hovers over the link.

I also realized that the creations were always displayed in alphabetical order (due to the nature of GitHub's API), which gave unfair visibility to certain creations. To solve this, I randomized the order in which they appeared.