### PR TITLE
Fixed invisible text

### DIFF
--- a/css/wow.css
+++ b/css/wow.css
@@ -16,9 +16,9 @@
 }
 
 .nav-link {
-    color: #848484;;    
+    color: #848484 !important;;
 }
 
 .nav-link:hover {
-    color: #000000;;    
+    color: #000000 !important;;
 }

--- a/css/wow.css
+++ b/css/wow.css
@@ -14,3 +14,11 @@
     padding: 1em;
   }
 }
+
+.nav-link {
+    color: #848484;;    
+}
+
+.nav-link:hover {
+    color: #000000;;    
+}

--- a/css/wow.css
+++ b/css/wow.css
@@ -16,7 +16,7 @@
 }
 
 .nav-link {
-    color: #848484 !important;;
+    color: #afafaf !important;;
 }
 
 .nav-link:hover {


### PR DESCRIPTION
Set the text color of the "Options" drop down menu links to a light gray so it doesn't blend in with the white background.